### PR TITLE
divide by zero fix

### DIFF
--- a/Image compression using K-Mean algorithm.ipynb
+++ b/Image compression using K-Mean algorithm.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "import random\n",
     "def init_centroids(X,K):\n",
-    "    c = random.sample(list(X),K)\n",
+    "    c = random.sample(list(np.unique(X,axis=0)),K)\n",
     "    return c"
    ]
   },


### PR DESCRIPTION
The code could give runtime:error - divide by zero
I have proposed a fix by first finding unique color pixels and then doing a random sample while finding the initial cluster centres.
Thanks for the code though.